### PR TITLE
Complete TDD-based unit tests

### DIFF
--- a/BloomFilter.xlam.src/BloomFilter.cls
+++ b/BloomFilter.xlam.src/BloomFilter.cls
@@ -112,8 +112,6 @@ End Function
 ' Estimated cardinality.
 Public Property Get Size() As Double
     
-    On Error GoTo Size_Err
-    
     Dim bits As Long
     Dim i As Integer
     
@@ -125,12 +123,6 @@ Public Property Get Size() As Double
     Next i
     
     Size = -pM * Log(1 - bits / pM) / pK
-    
-    Exit Property
-    
-Size_Err:
-    MsgBox "Warning: BloomFilter.Size() not fully implemented"
-    Size = -1
     
 End Property
 

--- a/BloomFilter.xlam.src/BloomFilter.cls
+++ b/BloomFilter.xlam.src/BloomFilter.cls
@@ -33,7 +33,7 @@ Private Sub Class_Initialize()
     Dim m, k As Integer
     
     '==== Default constructor values
-    m = 32 * 256    ' Number of bits. Must be a multiple of 32.
+    m = 32 * 1000   ' Number of bits. Must be a multiple of 32.
     k = 4           ' Number of hashing functions.
     '====
     
@@ -114,7 +114,7 @@ Public Property Get Size() As Double
     
     On Error GoTo Size_Err
     
-    Dim bits As Variant
+    Dim bits As Long
     Dim i As Integer
     
     bits = 0
@@ -171,15 +171,28 @@ Private Property Get Locations(ByVal v As String) As Variant
 End Property
 
 ' http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
-Private Function popcnt(ByVal v As Long) As Variant
+Private Function popcnt_1(ByVal v As Long, Optional sign As Boolean = False) As Integer
     ' Note: There is no Subtraction assignment (-=) operator in VBA by default
     
     v = v - (shr(v, 1) And &H55555555)
     v = (v And &H33333333) + (shr(v, 2) And &H33333333)
-    v = shr((v + shr(v, 4) And &HF0F0F0F) * (&H1010101), 24)
-    
-    popcnt = v
+    v = (v + shr(v, 4) And &HF0F0F0F)
+    v = v + shr(v, 8)
+    v = v + shr(v, 16)
+    v = v + shr(v, 32)
+    v = v And &H7F
+    If sign Then v = v + CLng(1)
+
+    popcnt_1 = v
 End Function
+    
+' http://www.vbforums.com/showthread.php?745693-Count-Bits-Extensions
+' Note how the 'sign' argument is determined, and how overflows
+' are inhibited by the use of a mask.
+Private Function popcnt(num As Long) As Integer
+    popcnt = popcnt_1(CLng(num And &H7FFFFFFF), num < 0)
+End Function
+
 
 ' http://www.excely.com/excel-vba/bit-shifting-function.shtml
 Private Function shr(ByVal Value As Long, ByVal Shift As Byte) As Long

--- a/test/bloomfilter-test.bas
+++ b/test/bloomfilter-test.bas
@@ -97,12 +97,12 @@ Public Function Specs() As SpecSuite
         For i = 0 To 100
             f.Add (i)
         Next i
-        .Expect(f.Size()).ToBeCloseTo 97.014763, 5
+        .Expect(f.Size()).ToBeCloseTo 99.61766, 5
 
         For i = 100 To 1000
             f.Add (i)
         Next i
-        .Expect(f.Size()).ToBeCloseTo 1007.54932, 5
+        .Expect(f.Size()).ToBeCloseTo 943.51438, 5
 
     End With
 

--- a/test/bloomfilter-test.bas
+++ b/test/bloomfilter-test.bas
@@ -51,6 +51,7 @@ Public Function Specs() As SpecSuite
     
         Set f = Nothing
         Set f = New BloomFilter
+        Dim n3 As String
 
         ' Will need to confirm the data type in VBA
         n1 = "\u0100"


### PR DESCRIPTION
Fixes Issue #1 by ensuring the BloomFilter.Size() probabilistic-based test clears.
- [x] Is it mergable?
- [x] Did it pass the tests on Windows, Excel 2003?
- [x] Did it pass the tests on Windows, Excel 2007?
- [x] Was a spellchecker run on the source code and documentation after changes were made?
